### PR TITLE
Removing links to original Google Document

### DIFF
--- a/Toward_the_evolving_OG_format_manual.md
+++ b/Toward_the_evolving_OG_format_manual.md
@@ -1,9 +1,0 @@
-# This file explains how to access the evolving version of the manual describing the OG format.
-
-You can access the evolving manual following the link below.
-It is editable by the OceanGliders data management team only. 
-This document is evolving as new issues and suggestions are raised.
-
-You can consult the document and post an issue or suggestion on github repository.
-
-https://docs.google.com/document/d/1Ri0V_xJjVRDaKKin0sBFk_6u1Dpt7Xwa/edit?usp=sharing&ouid=112615107763535351524&rtpof=true&sd=true

--- a/Toward_the_official_version_of_the_OG_format_manual.md
+++ b/Toward_the_official_version_of_the_OG_format_manual.md
@@ -1,5 +1,0 @@
-# Toward the official version of the format
-
-You can access the official current version of the format here : (to be released)
-
-Any suggestion of issues related to the OG data format should be published on the github repository.


### PR DESCRIPTION
Since we moved to GitHub, let's avoid confusion. It is lacking some
style formatting, but all the content was moved, so let's remove this
links to the original document and now on do all the modifications at
GitHub.

Those two files were from before the decision of moving the content to here.