### PR TITLE
Moving examples to an appendix

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -199,7 +199,9 @@ ___________________
 |Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |highly desirable |CF-1.8, ACDD-1.3, OG-1.0
 |=====================================================================================================================================================================================================================================================================================
 
-Note about program, networks and sites: The image below describe the architecture of the GOOS/OceanOPS data base.
+Note about program, networks, and sites:
+Some examples are provided in <<ProgramNetworkSite-example>>.
+The image below describes the architecture of the GOOS/OceanOPS database.
 
 image:figures/image2.png[image,width=515,height=171]
 
@@ -866,7 +868,7 @@ _Operational phase:_ 3 months – Oct 2022 to Dec 2023
 [appendix]
 == Examples
 
-[[ProgramNetworkSite-example]]
+[[ProgramNetworkSite-example, Examples using program, network, and site]]
 === Program, network, and site
 
 Example 1:

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -866,54 +866,55 @@ _Operational phase:_ 3 months – Oct 2022 to Dec 2023
 [appendix]
 == Examples
 
-=== Platform, Programme, and Network
+[[ProgramNetworkSite-example]]
+=== Program, network, and site
 
 Example 1:
 
 * platform (i.e. glider mission): kraken_20210205
-* Programme: MOOSE glider program
-* Sites: MOOSE_T00, MOOSET_02
+* Program: MOOSE glider program
+* Site: MOOSE_T00, MOOSET_02
 * Networks: Mediterranean Ocean Observing Systems for the Environment (MOOSE), Boundary Ocean Observing Network (BOON), Water Transformation task team”
 
 Example 2:
 
 * platform: sdeep09_sdeep04_20200929
-* Programme: SOCIB Glider Programme
-* Sites: Canales
+* Program: SOCIB Glider Programme
+* Site: Canales
 * Network: BOON
 
 Example 3:
 
 * platform: SG669-20210617
-* Programme: NOAA Hurricane Glider program
-* Sites: NPR1 (North Puerto Rico 1)
+* Program: NOAA Hurricane Glider program
+* Site: NPR1 (North Puerto Rico 1)
 * Networks: Integrated Ocean Observing System (IOOS), Caribbean Coastal Ocean Observing System (CARICOOS), Boundary Ocean Observing Network (BOON), OceanGliders Storms, AtlantOS
 
 Example 4:
 
 * platform: sp058-20210812T1703
-* Programme: Scripps glider program
-* Sites: CUGN90
+* Program: Scripps glider program
+* Site: CUGN90
 * Network: Integrated Ocean Observing System (IOOS), Southern California Coastal Ocean Observing System (SCCOOS), California Network Spray Program, Boundary Ocean Observing Network (BOON)
 
 Example 5:
 
 * platform: ce_917-20210730
-* Programme: OOI - Coastal and Endurance array
-* Sites: OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line
+* Program: OOI - Coastal and Endurance array
+* Site: OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line
 * Network: Ocean Observatories Initiative (OOI), Northwest Association of Networked Ocean Observing Systems (NANOOS), Boundary Ocean Observing Network (BOON)
 
 
 Example 6:
 
 * platform: SL287 - StormBay-15Apr21
-* Programme: Integrated Marine Observing System - Glider
-* Sites: no site
+* Program: Integrated Marine Observing System - Glider
+* Site: no site
 * Network: IMOS
 
 Example 7:
 
 * platform: stella_20180207
-* Programme: MARS Glider program
-* Sites: no site
+* Program: MARS Glider program
+* Site: no site
 * Network: Alter_ECO

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -877,43 +877,43 @@ Example 1:
 
 Example 2:
 
-* platform : sdeep09_sdeep04_20200929
-* Programme : SOCIB Glider Programme
-* Sites : Canales
-* Network : BOON
+* platform: sdeep09_sdeep04_20200929
+* Programme: SOCIB Glider Programme
+* Sites: Canales
+* Network: BOON
 
 Example 3:
 
-* platform : SG669-20210617
-* Programme : NOAA Hurricane Glider program
-* Sites : NPR1 (North Puerto Rico 1)
-* Networks : Integrated Ocean Observing System (IOOS), Caribbean Coastal Ocean Observing System (CARICOOS), Boundary Ocean Observing Network (BOON), OceanGliders Storms, AtlantOS
+* platform: SG669-20210617
+* Programme: NOAA Hurricane Glider program
+* Sites: NPR1 (North Puerto Rico 1)
+* Networks: Integrated Ocean Observing System (IOOS), Caribbean Coastal Ocean Observing System (CARICOOS), Boundary Ocean Observing Network (BOON), OceanGliders Storms, AtlantOS
 
 Example 4:
 
-* platform : sp058-20210812T1703
-* Programme : Scripps glider program
-* Sites : CUGN90
-* Network : Integrated Ocean Observing System (IOOS), Southern California Coastal Ocean Observing System (SCCOOS), California Network Spray Program, Boundary Ocean Observing Network (BOON)
+* platform: sp058-20210812T1703
+* Programme: Scripps glider program
+* Sites: CUGN90
+* Network: Integrated Ocean Observing System (IOOS), Southern California Coastal Ocean Observing System (SCCOOS), California Network Spray Program, Boundary Ocean Observing Network (BOON)
 
 Example 5:
 
-* platform : ce_917-20210730
-* Programme : OOI - Coastal and Endurance array
-* Sites : OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line
-* Network : Ocean Observatories Initiative (OOI), Northwest Association of Networked Ocean Observing Systems (NANOOS), Boundary Ocean Observing Network (BOON)
+* platform: ce_917-20210730
+* Programme: OOI - Coastal and Endurance array
+* Sites: OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line
+* Network: Ocean Observatories Initiative (OOI), Northwest Association of Networked Ocean Observing Systems (NANOOS), Boundary Ocean Observing Network (BOON)
 
 
 Example 6:
 
-* platform : SL287 - StormBay-15Apr21
-* Programme : Integrated Marine Observing System - Glider
-* Sites : no site
-* Network : IMOS
+* platform: SL287 - StormBay-15Apr21
+* Programme: Integrated Marine Observing System - Glider
+* Sites: no site
+* Network: IMOS
 
 Example 7:
 
-* platform : stella_20180207
-* Programme : MARS Glider program
-* Sites : no site
-* Network : Alter_ECO
+* platform: stella_20180207
+* Programme: MARS Glider program
+* Sites: no site
+* Network: Alter_ECO

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -870,10 +870,10 @@ _Operational phase:_ 3 months – Oct 2022 to Dec 2023
 
 Example 1:
 
-* platform (i.e. glider mission) = kraken_20210205
-* Programme = MOOSE glider program
-* Sites = MOOSE_T00, MOOSET_02
-* Networks = Mediterranean Ocean Observing Systems for the Environment (MOOSE), Boundary Ocean Observing Network (BOON), Water Transformation task team”
+* platform (i.e. glider mission): kraken_20210205
+* Programme: MOOSE glider program
+* Sites: MOOSE_T00, MOOSET_02
+* Networks: Mediterranean Ocean Observing Systems for the Environment (MOOSE), Boundary Ocean Observing Network (BOON), Water Transformation task team”
 
 Example 2:
 

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -203,55 +203,6 @@ Note about program, networks and sites: The image below describe the architectur
 
 image:figures/image2.png[image,width=515,height=171]
 
-Example 1:
-
-* platform (i.e. glider mission) = kraken_20210205
-* Programme = MOOSE glider program
-* Sites = MOOSE_T00, MOOSET_02
-* Networks = Mediterranean Ocean Observing Systems for the Environment (MOOSE), Boundary Ocean Observing Network (BOON), Water Transformation task team”
-
-Example 2:
-
-* platform : sdeep09_sdeep04_20200929
-* Programme : SOCIB Glider Programme
-* Sites : Canales
-* Network : BOON
-
-Example 3:
-
-* platform : SG669-20210617 
-* Programme : NOAA Hurricane Glider program
-* Sites : NPR1 (North Puerto Rico 1)
-* Networks : Integrated Ocean Observing System (IOOS), Caribbean Coastal Ocean Observing System (CARICOOS), Boundary Ocean Observing Network (BOON), OceanGliders Storms, AtlantOS 
-
-Example 4:
-
-* platform : sp054-20210406T1719
-* Programme : SCRIPPS glider program
-* Sites : CUGN80
-* Network : Integrated Ocean Observing System (IOOS), Southern California Coastal Ocean Observing System (SCCOOS), California Network Spray Program, Boundary Ocean Observing Network (BOON)
-
-Example 5:
-
-* platform : ce_917-20210730
-* Programme : OOI - Coastal and Endurance array
-* Sites : OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line  
-* Network : Ocean Observatories Initiative (OOI), Northwest Association of Networked Ocean Observing Systems (NANOOS), Boundary Ocean Observing Network (BOON)
-
-
-Example 6:
-
-* platform : SL287 - StormBay-15Apr21
-* Programme : Integrated Marine Observing System - Glider
-* Sites : no site
-* Network : IMOS
-
-Example 7:
-
-* platform : stella_20180207
-* Programme : MARS Glider program
-* Sites : no site
-* Network : Alter_ECO
 
 ////
 * [[dimension-and-definition]]
@@ -911,3 +862,58 @@ _Operational phase:_ 3 months – Oct 2022 to Dec 2023
 2 years after agreement on the Terms of Reference OG1.0 will become the unique format for the OceanGliders program.
 
 [[_heading=h.1egqt2p]]Glider missions not delivering OG1.0 will not be considered as part of the OceanGliders program. It will be encouraged that legacy files be converted and added to OceanGliders final repository
+
+[appendix]
+== Examples
+
+=== Platform, Programme, and Network
+
+Example 1:
+
+* platform (i.e. glider mission) = kraken_20210205
+* Programme = MOOSE glider program
+* Sites = MOOSE_T00, MOOSET_02
+* Networks = Mediterranean Ocean Observing Systems for the Environment (MOOSE), Boundary Ocean Observing Network (BOON), Water Transformation task team”
+
+Example 2:
+
+* platform : sdeep09_sdeep04_20200929
+* Programme : SOCIB Glider Programme
+* Sites : Canales
+* Network : BOON
+
+Example 3:
+
+* platform : SG669-20210617
+* Programme : NOAA Hurricane Glider program
+* Sites : NPR1 (North Puerto Rico 1)
+* Networks : Integrated Ocean Observing System (IOOS), Caribbean Coastal Ocean Observing System (CARICOOS), Boundary Ocean Observing Network (BOON), OceanGliders Storms, AtlantOS
+
+Example 4:
+
+* platform : sp058-20210812T1703
+* Programme : Scripps glider program
+* Sites : CUGN90
+* Network : Integrated Ocean Observing System (IOOS), Southern California Coastal Ocean Observing System (SCCOOS), California Network Spray Program, Boundary Ocean Observing Network (BOON)
+
+Example 5:
+
+* platform : ce_917-20210730
+* Programme : OOI - Coastal and Endurance array
+* Sites : OOI - Newport Harbor Inshore Line,  OOI - Newport Harbor offshore Line
+* Network : Ocean Observatories Initiative (OOI), Northwest Association of Networked Ocean Observing Systems (NANOOS), Boundary Ocean Observing Network (BOON)
+
+
+Example 6:
+
+* platform : SL287 - StormBay-15Apr21
+* Programme : Integrated Marine Observing System - Glider
+* Sites : no site
+* Network : IMOS
+
+Example 7:
+
+* platform : stella_20180207
+* Programme : MARS Glider program
+* Sites : no site
+* Network : Alter_ECO


### PR DESCRIPTION
Keep the document clean and short.

On the top of the example files, we should add plenty of examples in the document to help the reader, such as the ones added by @vturpin. To avoid a way too long document, what about collecting the examples in the appendix?