### PR TITLE
naming authority

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -123,17 +123,14 @@ _______________________________
 
  |mandatory |
 |naming_authority a|
-Name of the institution who provide the id
+A unique name that identifies the institution who provided the id.
+ACDD-1.3 recommends using reverse-DNS naming.
 
-* _____________
-Example: IOOS
-_____________
-* _____________
-Example: IMOS
-_____________
-* _________________
-Example: Coriolis
-_________________
+Examples:
+* IOOS
+* IMOS
+* Coriolis
+* edu.ucsd.spray
 
  |highly desirable |
 |institution a|


### PR DESCRIPTION
It's a free field as long as it is unique, but ACDD recommends using reverse-DNS. Adding an example.