### PR TITLE
Creating list of code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
 # This list was created based on the original authors of OG format
 
-* @glidermann @vturpin @castelao @justinbuck kerfoot@marine.rutgers.edu thierry.carval@ifremer.fr jfernandez@socib.es mun.woo@uwa.edu.au
+* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval jfernandez@socib.es mun.woo@uwa.edu.au

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Owners
+# This list was created based on the original authors of OG format
+
+* @glidermann @vturpin @castelao @justinbuck kerfoot@marine.rutgers.edu thierry.carval@ifremer.fr jfernandez@socib.es mun.woo@uwa.edu.au


### PR DESCRIPTION
This list was defined by @vturpin based on the original authors of OG-1.0 to speed up the approval procedure of final adjustments and corrections.