### PR TITLE
Missing standard_name for GPS lat & lon

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -243,6 +243,8 @@ double LATITUDE_GPS(N_MEASUREMENTS)
 
 LATITUDE_GPS:long_name = “latitude of each gps locations”;
 
+LATITUDE_GPS:standard_name = “latitude”;
+
 LATITUDE_GPS:unit = “decimal degree north”;
 
 LATITUDE_GPS:FillValue = “-9999.9”;
@@ -258,6 +260,8 @@ LATITUDE_GPS:ancillary_variables = "LATITUDE_GPS_QC"
 double LONGITUDE_GPS(N_MEASUREMENTS)
 
 LONGITUDE_GPS:long_name = “longitude of each gps locations”;
+
+LONGITUDE_GPS:standard_name = “longitude”;
 
 LONGITUDE_GPS:unit = “decimal degree east”;
 


### PR DESCRIPTION
Thanks to @soeren who noticed that on PR #35.