### PR TITLE
Conventions as mandatory

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -218,7 +218,7 @@ ___________________
 |comment |Miscellaneous information about the data or methods used to produce it. |suggested |
 |date_created |date of creation of this data set |mandatory |iso 8601
 |featureType |Description of a single feature with this discrete sampling geometry |mandatory |trajectory
-|Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |mandatory |CF-1.9, ACDD-1.3, OG-1.0
+|Conventions |A comma-separated list of the conventions that are followed by the dataset. |mandatory |ex.: "CF-1.9, ACDD-1.3, OG-1.0"
 |=====================================================================================================================================================================================================================================================================================
 
 Note about program, networks, and sites:

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -218,7 +218,7 @@ ___________________
 |comment |Miscellaneous information about the data or methods used to produce it. |suggested |
 |date_created |date of creation of this data set |mandatory |iso 8601
 |featureType |Description of a single feature with this discrete sampling geometry |mandatory |trajectory
-|Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |highly desirable |CF-1.8, ACDD-1.3, OG-1.0
+|Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |mandatory |CF-1.8, ACDD-1.3, OG-1.0
 |=====================================================================================================================================================================================================================================================================================
 
 Note about program, networks, and sites:

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -218,7 +218,7 @@ ___________________
 |comment |Miscellaneous information about the data or methods used to produce it. |suggested |
 |date_created |date of creation of this data set |mandatory |iso 8601
 |featureType |Description of a single feature with this discrete sampling geometry |mandatory |trajectory
-|Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |mandatory |CF-1.8, ACDD-1.3, OG-1.0
+|Conventions |A comma-separated list of the conventions that are followed by the dataset. For files that follow this version of ACDD, include the string 'ACDD-1.3' |mandatory |CF-1.9, ACDD-1.3, OG-1.0
 |=====================================================================================================================================================================================================================================================================================
 
 Note about program, networks, and sites:


### PR DESCRIPTION
@vturpin noticed on #76 that `Conventions` was not required. This is an important field to guide expected behavior for applications. This is too easy to set up, and no reason to don't be mandatory.

- Following @vturpin , Conventions should be mandatory
- CF-1.9 is backward compatible hence it also satisfies CF-1.8