### PR TITLE
Improve deployment variables

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -519,7 +519,13 @@ PLATFORM_MAKER:platform_maker_vocabulary = “”;
 |DEPLOYMENT_TIME a|
 double DEPLOYMENT_TIME
 
-long_name = “date of deployment”;
+DEPLOYMENT_TIME:long_name = “date of deployment”;
+
+DEPLOYMENT_DATE:standard_name = "time";
+
+DEPLOYMENT_DATE:calendar = "gregorian";
+
+DEPLOYMENT_DATE:units = "seconds since 1970-01-01T00:00:00Z";
 
  |mandatory
 |DEPLOYMENT_LATITUDE a|

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -521,11 +521,11 @@ double DEPLOYMENT_TIME
 
 DEPLOYMENT_TIME:long_name = “date of deployment”;
 
-DEPLOYMENT_DATE:standard_name = "time";
+DEPLOYMENT_TIME:standard_name = "time";
 
-DEPLOYMENT_DATE:calendar = "gregorian";
+DEPLOYMENT_TIME:calendar = "gregorian";
 
-DEPLOYMENT_DATE:units = "seconds since 1970-01-01T00:00:00Z";
+DEPLOYMENT_TIME:units = "seconds since 1970-01-01T00:00:00Z";
 
  |mandatory
 |DEPLOYMENT_LATITUDE a|

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -529,13 +529,13 @@ DEPLOYMENT_DATE:units = "seconds since 1970-01-01T00:00:00Z";
 
  |mandatory
 |DEPLOYMENT_LATITUDE a|
-string DEPLOYMENT_LATITUDE
+double DEPLOYMENT_LATITUDE
 
 DEPLOYMENT_LATITUDE:long_name = “latitude of deployment”;
 
  |mandatory
 |DEPLOYMENT_LONGITUDE a|
-string DEPLOYMENT_LONGITUDE
+double DEPLOYMENT_LONGITUDE
 
 long_name = “longitude of deployment”;
 

--- a/sp041_20191205T1757.cdl
+++ b/sp041_20191205T1757.cdl
@@ -138,19 +138,19 @@ variables:
 	byte DOXY_QC(N_MEASUREMENTS) ;
 		DOXY_QC:_FillValue = 0b ;
 		DOXY_QC:long_name = "quality flag" ;
-	string DEPLOYMENT_DATE ;
-		DEPLOYMENT_DATE:long_name = "date of deployment" ;
-		DEPLOYMENT_DATE:standard_name = "time" ;
-		DEPLOYMENT_DATE:calendar = "gregorian" ;
-		DEPLOYMENT_DATE:units = "seconds since 1970-01-01T00:00:00Z" ;
-		DEPLOYMENT_DATE:axis = "T" ;
-	string DEPLOYMENT_LATITUDE ;
+	double DEPLOYMENT_TIME ;
+		DEPLOYMENT_TIME:long_name = "date of deployment" ;
+		DEPLOYMENT_TIME:standard_name = "time" ;
+		DEPLOYMENT_TIME:calendar = "gregorian" ;
+		DEPLOYMENT_TIME:units = "seconds since 1970-01-01T00:00:00Z" ;
+		DEPLOYMENT_TIME:axis = "T" ;
+	double DEPLOYMENT_LATITUDE ;
 		DEPLOYMENT_LATITUDE:long_name = "latitude of deployment" ;
 		DEPLOYMENT_LATITUDE:standard_name = "latitude" ;
 		DEPLOYMENT_LATITUDE:units = "degrees_north" ;
 		DEPLOYMENT_LATITUDE:valid_max = "90" ;
 		DEPLOYMENT_LATITUDE:valid_min = "-90" ;
-	string DEPLOYMENT_LONGITUDE ;
+	double DEPLOYMENT_LONGITUDE ;
 		DEPLOYMENT_LONGITUDE:long_name = "longitude of deployment" ;
 		DEPLOYMENT_LONGITUDE:standard_name = "longitude" ;
 		DEPLOYMENT_LONGITUDE:units = "degrees_east" ;
@@ -316,11 +316,11 @@ data:
  DOXY_QC = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
     _, _, _ ;
 
- DEPLOYMENT_DATE = "1575570735.0" ;
+ DEPLOYMENT_TIME = 1575570735.0 ;
 
- DEPLOYMENT_LATITUDE = "32.9018" ;
+ DEPLOYMENT_LATITUDE = 32.9018 ;
 
- DEPLOYMENT_LONGITUDE = "-117.29972500000001" ;
+ DEPLOYMENT_LONGITUDE = -117.29972500000001 ;
 
  PLATFORM_TYPE = "Spray" ;
 


### PR DESCRIPTION
- I believe that at some point, the deployment time was accepted as double, which requires some attributes to make sense of it.
- It doesn't make sense to use String for deployment lat/lon, right?

I think this was identified by @vturpin.