### PR TITLE
build docs on push to main

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -1,6 +1,7 @@
 name: Export and publish document
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
 

--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -1,7 +1,8 @@
 name: Export and publish document
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
This will automatically build the documentation site when a push is made to the main branch, keeping the docs up to date