### PR TITLE
Remove Reporting, Agenda, updating Best Practices policy

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -786,13 +786,13 @@ Vocabularies will be fully defined during the implementation phase of the OG1.0.
 ////
 == Best practices
 
-Methodologies used to compute OG1.0 format need publishing as best practices document in the IODE Ocean Best Practice repository (https://repository.oceanbestpractices.org/[_https://repository.oceanbestpractices.org/_]) under the community “OceanGliders” and the collection “data management”. It covers the following topic:
+Methodologies used to produce files meeting the OG format should be published in the IODE Ocean Best Practice (OBP) repository (https://repository.oceanbestpractices.org/[_https://repository.oceanbestpractices.org/_]) under the community “OceanGliders” and the collection “data management”. The following methodologies are covered, among others:
 
-* Interpolation methodologies
-* PHASE computing methodologies
-* RTQC methodologies
+* Interpolation
+* PHASE computation
+* RTQC 
 
-Methodologies should describe the computation methods used by DAC to produce the data set. Methodologies should have a DOI and be labialized as “OceanGliders practices” by the OceanGliders data management task team.
+Methodologies should describe the computation methods used (typically by Data Assembly Centers) to produce the data set. OBP publications are assigned a DOI and should be tagged as “OceanGliders practices” by the OceanGliders data management task team after a review process.
 
 ////
 * [[evolution-process-inclusion-of-new-variables.]]
@@ -801,42 +801,6 @@ Methodologies should describe the computation methods used by DAC to produce the
 == Evolution process, the inclusion of new variables.
 
 Management of the evolution of the format will be organized by the OceanGliders data management team.
-
-////
-* [[reporting]]
-= Reporting
-////
-== Reporting
-
-The meeting will be organized (every 6 months?) with DACs to report about the implementation process until September 2023.
-
-////
-* [[agenda]]
-= Agenda
-////
-== Agenda
-
-__Agreement on the Term of Reference__: 3 months – Jan 2021 – March 2021
-
-A proposal will be delivered by the working group on December 14^th^ for endorsement by the OceanGliders steering committee.
-
-The OG1.0 ToR will be addressed to the OceanGliders community for questions and feedback for 3 months.
-
-Our working group will agree on a final version of the common format.
-
-__Implementation phase__: 18 months – April 2021 to Oct 2022
-
-During the implementation phase, operators, DACs and GDACs will develop tools and procedures to produce real-time gliders data files compliant with OG1.0 requirements described in the ToR.
-
-Regular meetings (frequency to be discussed) will be organized by the data management task team and DACs to evaluate progress in the different steps of the implementation phase.
-
-The OceanGliders data management team will agree on vocabulary collection.
-
-_Operational phase:_ 3 months – Oct 2022 to Dec 2023
-
-2 years after the agreement on the Terms of Reference OG1.0 will become the unique format for the OceanGliders program.
-
-Glider missions not delivering OG1.0 will not be considered as part of the OceanGliders program. It will be encouraged that legacy files be converted and added to OceanGliders final repository
 
 [appendix]
 == Examples

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -792,7 +792,7 @@ Methodologies used to produce files meeting the OG format should be published in
 * PHASE computation
 * RTQC 
 
-Methodologies should describe the computation methods used (typically by Data Assembly Centers) to produce the data set. OBP publications are assigned a DOI and should be tagged as “OceanGliders practices” by the OceanGliders data management task team after a review process.
+Methodologies should describe the computation methods used (typically by Data Assembly Centers) to produce the data set. Ocean Best Practices are assigned a DOI and should be tagged as "OceanGliders" practices by the submitter. Additionally, OBP endorsed by the OceanGliders data management task team will be marked as such.
 
 ////
 * [[evolution-process-inclusion-of-new-variables.]]


### PR DESCRIPTION
Removed Reporting and Agenda sections and modified best practices section. I am not sure if DMTT should review OBP submissions before tagging them as OG, or if submitter can do it using their own judgment.


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [ ] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [x] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
<!-- If there is an issue associated with this PR, please add it here.
Example: See issue #0 for related discussion
See issue #XXX for discussion of these changes.
-->

# Dates when it got review approvals
<!-- This is important to check if it was given sufficient time for other comments -->

# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments
<!-- If the modifications need any extra comments or explanations -->
