### PR TITLE
Change agency into institution.adoc

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -188,11 +188,11 @@ ex.:
 |contributor_id |Unique id of the contributors to the glider mission. Multiple contributors’ ids are separated by commas. |highly desirable |
 |contributor_role |Role of the contributors to the glider mission. Multiple contributors’ roles are separated by commas. |PI vocabulary is mandatory |
 |contributor_role_vocabulary |Controlled vocabulary for the roles used in the "contributors_role". Multiple contributors’ roles and vocabularies are separated by commas. |PI vocabulary is mandatory |http://vocab.nerc.ac.uk/search_nvs/W08/[_http://vocab.nerc.ac.uk/search_nvs/W08/_]
-|agency |Name of agencies involved in the glider mission. Multiple agencies are separated by commas. |operating agency is mandatory |
-|agency_role |Role of the agencies involved in the glider mission. Multiple agencies’ roles are separated by a comma. |operating agency role is mandatory |
-|agency_role_vocabulary |The controlled vocabulary of the role used in the agency’s role. Multiple vocabularies are separated by commas. |operating agency vocabulary is mandatory |https://vocab.nerc.ac.uk/collection/C86/current/[_https://vocab.nerc.ac.uk/collection/C86/current/_]
-|agency_id |code of the agency involved in the glider mission. Multiple ids are separated by a comma. |highly desirable |
-|agency_id_vocabulary |url to the repository of the id |highly desirable |EDMO, ROR, etc.
+|institution |Name of institutions involved in the glider mission. Multiple institution are separated by commas. |operating institution is mandatory |
+|institution_role |Role of the institutions involved in the glider mission. Multiple institution’s roles are separated by a comma. |operating institution role is mandatory |
+|institution_role_vocabulary |The controlled vocabulary of the role used in the institution’s role. Multiple vocabularies are separated by commas. |operating institution vocabulary is mandatory |https://vocab.nerc.ac.uk/collection/C86/current/[_https://vocab.nerc.ac.uk/collection/C86/current/_]
+|institution_id |code of the institution involved in the glider mission. Multiple ids are separated by a comma. |highly desirable |
+|institution_id_vocabulary |url to the repository of the id |highly desirable |EDMO, ROR, etc.
 |uri |Other universal resource identifiers relevant to be linked to this dataset. Multiple uris are separated by a comma. |suggested |EDIOS, CSR, EDMERP, EDMED, CDI, ICES, etc.
 |data_url |url link to OG1.0 data file |mandatory |
 |doi |The digital object identifier of the OG1.0 data file |highly desirable |


### PR DESCRIPTION
"Institution" is used by the three orginial format. While agency isn't. To keep it as simple as possible and facilitate use of the new format, we suggest here to move from agency to institution in the OG1.0.

Agency comes from OceanOPS vocabularies only. There is no strong reason not to use institution as it is already a concept used by the key DACs.  We did not pay attention to that details until now.


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [X] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [ ] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
(https://github.com/OceanGlidersCommunity/OG-format-user-manual/issues/153)

# Dates when it got review approvals
<!-- This is important to check if it was given sufficient time for other comments -->

# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments
<!-- If the modifications need any extra comments or explanations -->
