### PR TITLE
Missing Emma in the code reviewers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
 # This list was created based on the original authors of OG format
 
-* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval jfernandez@socib.es mun.woo@uwa.edu.au
+* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval @emmerbodc jfernandez@socib.es mun.woo@uwa.edu.au


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [ ] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [X] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
<!-- If there is an issue associated with this PR, please add it here.
Example: See issue #0 for related discussion
See issue #XXX for discussion of these changes.
-->

# Dates when it got review approvals
<!-- This is important to check if it was given sufficient time for other comments -->

# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments
<!-- If the modifications need any extra comments or explanations -->
I just noticed that it was missing @emmerbodc  in the list of reviewers.