### PR TITLE
typo in the table of parameter

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -228,11 +228,11 @@ image:figures/image2.png[image,width=515,height=171]
 [cols=",,,",options="header",]
 |=================================================================================================================================================================================================================================================================
 
-|*Name* |*Definition* |*Comment*
-|N_MEASUREMENTS |N_MEASUREMENTS = unlimited; |Number of recorded locations.
-| N_SENSOR| N_SENSOR = <int value>; | Number of sensors mounted on the float and used to measure the parameters. 
-Example for a float with CTD, ECO_FLBBCD and OPTODE: CTD_TEMP, CTD_PRES, CTD_CNDC, OPTODE_DOXY, FLUOROMETER_CHLA, FLUOROMETER_CDOM, BACKSCATTERINGMETER_BBP700 ; N_SENSOR = 7
-|N_PARAM |N_PARAM = <int value>; |Number of parameters measured or calculated for a pressure sample. Examples for a float with CTD, ECO_FLBBCD and OPTODE : PRES, TEMP, CNDC, PSAL,  MOLAR_DOXY, TEMP_DOXY, CHLA, CDOM, BETA700) : N_PARAM = 9
+|*Name* |*Definition* |*Comment*|
+|N_MEASUREMENTS |N_MEASUREMENTS = unlimited; |Number of recorded locations|
+|N_SENSOR| N_SENSOR = <int value>; | Number of sensors mounted on the float and used to measure the parameters. 
+Example for a float with a CTD, an ECO_FLBBCD and an OPTODE: Sensors are : CTD_TEMP, CTD_PRES, CTD_CNDC, OPTODE_DOXY, FLUOROMETER_CHLA, FLUOROMETER_CDOM, BACKSCATTERINGMETER_BBP700 ; N_SENSOR = 7|
+|N_PARAM |N_PARAM = <int value>; |Number of parameters measured or calculated for a pressure sample. Examples for a float with CTD, ECO_FLBBCD and OPTODE : PRES, TEMP, CNDC, PSAL,  MOLAR_DOXY, TEMP_DOXY, CHLA, CDOM, BETA700) : N_PARAM = 9|
 
 |=================================================================================================================================================================================================================================================================
 


### PR DESCRIPTION
There was a typo in the table parameter that impact the display of the table. "|" was missing at the end of each row.


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [X] Typo without possible change of interpretation of the related text.
- [X] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [ ] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
<!-- If there is an issue associated with this PR, please add it here.
Example: See issue #0 for related discussion
See issue #XXX for discussion of these changes.
-->

# Dates when it got review approvals
<!-- This is important to check if it was given sufficient time for other comments -->

# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments
<!-- If the modifications need any extra comments or explanations -->
