### PR TITLE
remove RTQC from global attribute.adoc

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -203,8 +203,6 @@ ex.:
 |uri |Other universal resource identifiers relevant to be linked to this dataset. Multiple uris are separated by a comma. |suggested |EDIOS, CSR, EDMERP, EDMED, CDI, ICES, etc.
 |data_url |url link to OG1.0 data file |mandatory |
 |doi |The digital object identifier of the OG1.0 data file |highly desirable |
-|rtqc_method |The method used by DAC to apply real-time quality control to the data set |mandatory |
-|rtqc_method_doi |The digital object identifier of the methodology used to apply real-time quality control to the data set. |mandatory |
 |web_link |url that provides useful information about anything related to the glider mission. Multiple urls are separated by commas. |suggested |
 |comment |Miscellaneous information about the data or methods used to produce it. |suggested |
 |date_created |date of creation of this data set |mandatory |iso 8601


### PR DESCRIPTION
I removed RTQC reference in the global attribute following recommendation made in issue #170 . The only reference to RTQC is made at the PARAM variable level now.


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [X] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [ ] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
<!-- If there is an issue associated with this PR, please add it here.
Example: See issue #0 for related discussion
See issue #XXX for discussion of these changes.
-->

# Dates when it got review approvals
<!-- This is important to check if it was given sufficient time for other comments -->

# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments
<!-- If the modifications need any extra comments or explanations -->
