### PR TITLE
platform name default to serial number

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -440,7 +440,7 @@ If the glider has no <platform_name> use <platform_serial_number> instead to cre
 * long_name = “unique identifying name of glider”;
  |mandatory
 
- The  platform name should be constructed from the manufacturer prefix and the platform serial number e.g. "sea001" (seaglider), unit_001 (slocum), sea001 (seaexplorer), sp001 (spray). Where the serial number of the platform is not known, a local nickname can be used e.g. "orca", "sverdrup", "ammonite".
+ The  platform name should be constructed from the manufacturer prefix and the platform serial number e.g. "sea001" (seaglider), unit001 (slocum), sea001 (seaexplorer), sp001 (spray). Where the serial number of the platform is not known, a local nickname can be used e.g. "orca", "sverdrup", "ammonite".
 
 |PLATFORM_DEPTH_RATING 
 

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -437,8 +437,10 @@ If the glider has no <platform_name> use <platform_serial_number> instead to cre
 |PLATFORM_NAME 
 
 * data type: string|
-* long_name = “Local or nickname of the glider”;
- |highly desirable
+* long_name = “unique identifying name of glider”;
+ |mandatory
+
+ The  platform name should be constructed from the manufacturer prefix and the platform serial number e.g. "sea001" (seaglider), unit_001 (slocum), sea001 (seaexplorer), sp001 (spray). Where the serial number of the platform is not known, a local nickname can be used e.g. "orca", "sverdrup", "ammonite".
 
 |PLATFORM_DEPTH_RATING 
 


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [x] Fix of some error, inconsistency, unforeseen limitation.


This PR resolved #181. Following the March meeting, it was decided to prefer serial number e.g. sea637 to identify gliders, over the local nickname of the glider e.g. "orca". The local nickname is still acceptable.

This also makes PLATFORM_NAME mandatory, as it is used to construct the dataset id and filename, which are essential.
