### PR TITLE
Add vocabularies webpage built from asciidoc

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -1,40 +1,15 @@
-name: Export and publish document
+name: Make pages
 
 on:
   workflow_dispatch:
   push:
     branches: [ main ]
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-
-    - name: Generate HTML document
-      uses: Analog-inc/asciidoctor-action@v1.2.2
-      with:
-        shellcommand: "asciidoctor --verbose -D build -o index.html OG_Format.adoc; cp -r figures build/"
-    - name: Generate PDF document
-      uses: Analog-inc/asciidoctor-action@v1.2.2
-      with:
-        shellcommand: "asciidoctor-pdf --verbose -d book OG_Format.adoc -D build"
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3.0.1
-      with:
-        path: 'build'
-
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@main
+    - name: asciidoctor-ghpages
+      uses: manoelcampos/asciidoctor-ghpages-action@v2.3.0

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -1,7 +1,13 @@
 [cols=",",options="header",]
 |===========================================================================================
 |image:figures/image1.png[image,width=164,height=144] a|
-OceanGliders 1.0 format - Terms of References
+OceanGliders 1.0 format - Terms of References +
+
+Navigation: +
+
+https://github.com/OceanGlidersCommunity/OG-format-user-manual[Github repository]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html[Terms of reference]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/vocabularyCollection/tableOfControlledVocab.html[Vocabulary collections]  +
 
 |===========================================================================================
 
@@ -756,7 +762,7 @@ Note 1: PARAMETER information is highly desirable to avoid ERDDAP configuration 
 * [[geophysical-variables]]
 = Geophysical variables
 ////
-= Geophysical variables
+== Geophysical variables
 "The fill value should have the same data type as the variable and be outside of the range of possible data values."
 [cols=",,",options="header",]
 |==========================================================================================================================

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -858,24 +858,24 @@ It is expected that the vocabulary collections will not always been synchronized
 
   | platform | https://vocab.nerc.ac.uk/collection/L06/current/25/[collection] |  https://vocab.nerc.ac.uk/collection/L06/current/25/ | OceanGliders |
   | oceangliders_site | *tbd* |  *tbd* | OceanOPS |
-  | contributors_role | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/contributors_role.md[collection] |  *tbd* | OceanGliders |
-  | agencies_role | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/agencies_role[collection] |  *tbd* | OceanGliders |
+  | contributors_role | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/contributors_role.md[collection] |  *tbd* | OceanGliders |
+  | agencies_role | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/agencies_role[collection] |  *tbd* | OceanGliders |
   | agencies_id | https://edmo.seadatanet.org/[collection] |  https://edmo.seadatanet.org/ | SeaDataNet |
   | naming_authority | https://edmo.seadatanet.org/[collection] |  https://edmo.seadatanet.org/ | SeaDataNet |
   | institution | https://edmo.seadatanet.org/[collection] |  https://edmo.seadatanet.org/ | SeaDataNet |
-  | rtqc_method | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/rtqc_method.md[collection] |  https://vocab.nerc.ac.uk/collection/L06/current/25/ | OceanGliders |
+  | rtqc_method | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/rtqc_method.md[collection] |  https://vocab.nerc.ac.uk/collection/L06/current/25/ | OceanGliders |
   | phase_calculation_methodology | *tbd* |  *tbd* | OceanGliders |
-  | platform_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/platform_type.md[collection] | http://vocab.nerc.ac.uk/collection/L06/current/27/ | OceanGliders |
-  | platform_model | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/platform_model.md[collection] |  *tbd* | OceanGliders |
+  | platform_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/platform_type.md[collection] | http://vocab.nerc.ac.uk/collection/L06/current/27/ | OceanGliders |
+  | platform_model | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/platform_model.md[collection] |  *tbd* | OceanGliders |
   | ICES_code | https://vocab.ices.dk/?codetypeguid=7f9a91e1-fb57-464a-8eb0-697e4b0235b5[collection] |  https://vocab.ices.dk/?codetypeguid=7f9a91e1-fb57-464a-8eb0-697e4b0235b5 | ICES |
-  | platform_maker | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/platform_maker.md[collection] |  *tbd* | OceanGliders |
-  | battery_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/battery_type.md[collection] |  *tbd* | OceanGliders |
-  | telecom_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/telecom_type.md[collection] |  *tbd* | OceanGliders |
-  | tracking_system | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/tracking_system.md[collection] |  *tbd* | OceanGliders |
+  | platform_maker | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/platform_maker.md[collection] |  *tbd* | OceanGliders |
+  | battery_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/battery_type.md[collection] |  *tbd* | OceanGliders |
+  | telecom_type | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/telecom_type.md[collection] |  *tbd* | OceanGliders |
+  | tracking_system | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/tracking_system.md[collection] |  *tbd* | OceanGliders |
   | sensor | *tbd* |  *tbd* | OceanGliders |
   | sensor_model | *tbd* |  *tbd* | OceanGliders |
-  | data_mode | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/data_mode.md[collection] |  *tbd* | OceanGliders |
-  | phase | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/vturpin-patch-3-VocabularyCollectionSection/vocabularyCollection/phase.md[collection] |  *tbd* | OceanGliders |
+  | data_mode | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/data_mode.md[collection] |  *tbd* | OceanGliders |
+  | phase | https://github.com/OceanGlidersCommunity/OG-format-user-manual/blob/main/vocabularyCollection/phase.md[collection] |  *tbd* | OceanGliders |
   | parameter | *tbd* |  http://vocab.nerc.ac.uk/collection/OG1/current/ | OceanGliders |
 |===
   

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 Here we review issues related to OceanGliders (OG) format and vocabularies.
 A discussion section is also available for any question or comment related to OG format and vocabulary.
 
-[Here](https://oceangliderscommunity.github.io/OG-format-user-manual/) is the most recent version of the user manual. 
+The homepage of OG format is at [https://github.com/OceanGlidersCommunity/OG-format-user-manual](https://github.com/OceanGlidersCommunity/OG-format-user-manual)
+
+[Here](https://oceangliderscommunity.github.io/OG-format-user-manual/) is the most recent version of the user manual.
+
+
+Vocabulary guidance for the OG format is [here](https://oceangliderscommunity.github.io/OG-format-user-manual/vocabularyCollection/tableOfControlledVocab.html)
+
+The history of the format is documented on the [history page](https://oceangliderscommunity.github.io/OG-format-user-manual/history.html)
 
 ### Example files
 
@@ -34,3 +41,4 @@ The release is planned for January each year. Issues accepted in September shoul
 ## Code of Conduct
 
 Please read and follow our [Code of Conduct](https://github.com/OceanGlidersCommunity/OceanGliders/blob/main/CODE_OF_CONDUCT.md).
+

--- a/vocabularyCollection/tableOfControlledVocab.adoc
+++ b/vocabularyCollection/tableOfControlledVocab.adoc
@@ -1,10 +1,15 @@
 [cols=",",options="header",]
 |===========================================================================================
-|image:figures/image1.png[image,width=164,height=144] a|
-OceanGliders 1.0 format - Vocabulary Collections
+|image:../figures/image1.png[image,width=164,height=144] a|
+OceanGliders 1.0 format - Vocabulary Collections +
+
+Navigation: +
+
+https://github.com/OceanGlidersCommunity/OG-format-user-manual[Github repository]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html[Terms of reference]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/vocabularyCollection/tableOfControlledVocab.html[Vocabulary collections]  +
 
 |===========================================================================================
-
 ////
 * [[Vocabulary Collections]]
 ////


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [x] Style that only affects visually the compiled document

This PR builds all .adoc pages in the repo into html, so the vocabularies and history documents both appear on the website too.

I've also added links between the documents and fixed broken links to the preliminary vocab tables.

I suggest merging this promptly for vocab work. The changes to the website will only be visible after merging

