### PR TITLE
Update link to OGformat to new GH pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A discussion section is also available for any question or comment related to OG
 
 The homepage of OG format is at [https://github.com/OceanGlidersCommunity/OG-format-user-manual](https://github.com/OceanGlidersCommunity/OG-format-user-manual)
 
-[Here](https://oceangliderscommunity.github.io/OG-format-user-manual/) is the most recent version of the user manual.
+[Here](https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html) is the most recent version of the user manual.
 
 
 Vocabulary guidance for the OG format is [here](https://oceangliderscommunity.github.io/OG-format-user-manual/vocabularyCollection/tableOfControlledVocab.html)


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [x] Typo without possible change of interpretation of the related text.

This PR updates the link on the README to the new url of the format on github pages.

I had to change the Settings/Pages source to get github to load the new pages build. You should be able to reach web pages of the format, vocabularies and history from the readme. Let me know if it's not intuitive @emmerbodc @vturpin 
