### PR TITLE
Create metadataFormat.adoc

### DIFF
--- a/metadataFormat/metadataFormat.adoc
+++ b/metadataFormat/metadataFormat.adoc
@@ -1,0 +1,32 @@
+[cols=",",options="header",]
+|===========================================================================================
+|https://www.oceangliders.org/[image:figures/image1.png[image,width=164,height=144]] a|
+OceanGliders 1.0 format - metadata format +
+
+Navigation: +
+
+https://github.com/OceanGlidersCommunity/OG-format-user-manual[GitHub repository]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html[Terms of reference]  +
+https://oceangliderscommunity.github.io/OG-format-user-manual/vocabularyCollection/tableOfControlledVocab.html[Vocabulary collections]  +
+
+|===========================================================================================
+
+////
+* [[Metadata format]]
+////
+= General information
+The metadata format of OceanGliders (here after OG1.0.json) should be deliver by DACs along with OceanGliders trajectory files.
+OG1.0.json metadata file contains descriptive information about an glider mission.
+
+= File naming convention
+OG1.0.json follow the file naming convention of the OG1.0.nc trajectory files. Metadata files should be named as follows:
+
+	- "<id>.json" (ex : "sp065_20210616T143025.json")
+
+Where <id> = "<platform_serial>_<start_date>" (ex : "sp065_20210616T143025.json")
+
+= File header
+"0G_metadata_format_version": "1.0",
+
+= Global attribute
+The following attributes should appear in the global attribute section of the OG1.O.json. 


### PR DESCRIPTION
Following issue #75 and anticipating on OG1.0 format delivery. I am proposing here a metadata file that will agregate all metadata into a json file, easy to read and very usefull for monitoring (amongst other thing).

This is a practice adopted by Argo with very good results in terms of monitoring.

This is to be discussed amongst each other and not to be tackle before the iugc2024.


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [ ] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [X] Addition that does not require change in the current structure.
- [X] Enhancement that require changes to improve the format.

# Related Issues
#75 

# Dates when it got review approvals
After iugc2024
