### PR TITLE
Remove note about QC flag.adoc

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -738,9 +738,6 @@ Byte <PARAM>_QC(N_MEASUREMENT); <PARAM>_QC:long_name = "quality flag";
  |higly desirable
 |==========================================================================================================================
 
-Note: It is anticipated to upgrade the ancillary variable related to QC by refining the ancillary variable name like < PARAM >_qc_generic, < PARAM >_qc_spike_test, <PARAM>_qc_land_test, etc. Current _QC attributes based on CF guidance (http://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#flags)
-and use the GOOS networks 0-4 flagging convention.
-
 
 ////
 * [[best-practices]]


### PR DESCRIPTION
To clean the doc and not loosing this important comment I remove the bottom page note and turn it into an issue for future release (OG1.X)


Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [ ] Fix of some error, inconsistency, unforeseen limitation.
- [X] Style that only affects visually the compiled document
- [ ] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related issue
#226 
