### PR TITLE
Reorder listing of coordinates in PARAM attribute documentation

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -742,7 +742,7 @@ float <PARAM>(N_MEASUREMENT);
 
 <PARAM>:ancillary_variables = "<PARAM>_QC";
 
-<PARAM>:coordinates = "LATITUDE, LONGITUDE, DEPTH, TIME"
+<PARAM>:coordinates = "TIME, LONGITUDE, LATITUDE, DEPTH"
 
 <PARAM>:sensor = "SENSOR_<sensor_type>_<sensor_serial_number>"
 
@@ -769,7 +769,7 @@ units = "mS cm-1"
 
 ancillary_variables = "CNDC_QC";
 
-coordinates = "LATITUDE, LONGITUDE, DEPTH, TIME"
+coordinates = "TIME, LONGITUDE, LATITUDE, DEPTH"
 
 sensor = "SENSOR_CTD_206523"
 


### PR DESCRIPTION
Modifies the PARAM documentation section in in  OG_Format.adoc. 

Per @emmerbodc - agreed in meeting yesterday, coordinates needs re-ordering based on most popular standard.


Proponents: @jenseva
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [ ] Typo without possible change of interpretation of the related text.
- [ x] Fix of some error, inconsistency, unforeseen limitation.
- [ ] Style that only affects visually the compiled document
- [ ] Addition that does not require change in the current structure.
- [ ] Enhancement that require changes to improve the format.

# Related Issues
See issue #240 for related discussion
[https://github.com/OceanGlidersCommunity/OG-format-user-manual/issues/240](https://github.com/OceanGlidersCommunity/OG-format-user-manual/issues/240)

# Dates when it got review approvals


# Release checklist

- [ ] Approved by at least two members of the committee?
- [ ] There were modifications after the review approvals? If so, please
      ask reviewers to update their review.
- [ ] Proponents and moderador should explicitly agree that it is ready to
      to merge.
- [ ] The moderador is the one in charge to actually merge or close this PR
      according to the final decision.

# For maintainers

- [ ] Update the moderator with a volunteer from the committee. It would be
      best to have one single moderator to guide and help this PR to move
      forward. It is OK to update the moderador pass it to another one.
- [ ] Confirm that the associated branch was deleted after the merging.
- [ ] Wrap-up and close the related issues.

# Comments

