### PR TITLE
Add Jenn to codewowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
 # This list was created based on the original authors of OG format
 
-* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval @emmerbodc @callumrollo @JuangaSocib
+* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval @emmerbodc @jenseva @callumrollo @JuangaSocib


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

Following today's meeting, propose adding @jenseva to codeowners so she can review PRs.

As always, this will require two approvals! @emmerbodc  @vturpin 
