### PR TITLE
propose segment and profile variables

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -683,6 +683,34 @@ PHASE_QC:flag_meanings = "No QC has been applied,
 			Bad data" ;
 
  |Highly desirable
+
+ |SEGMENT
+
+* data type: integer
+* dimension: N_MEASUREMENTS |
+
+SEGMENT_NUMBER:long_name = “Identifier of numbered segment within the dataset”;
+
+SEGMENT_NUMBER:segment_number_calculation_method = SEGMENT_NUMBER is 0 at the start of a deployment. SEGMENT_NUMBER increments by 1 each time the glider enters the surface phase (PHASE=3)”;
+
+SEGMENT_NUMBER:_FillValue = -9999 ;
+
+|Highly desirable
+
+ |PROFILE_NUMBER
+
+* data type: integer
+* dimension: N_MEASUREMENTS |
+
+PROFILE_NUMBER:long_name = “Identifier of numbered segment within the dataset”;
+
+PROFILE_NUMBER:profile_number_calculation_method = "PROFILE_NUMBER is 0 at the start of a deployment. PROFILE_NUMBER increments by 1 each time a glider enters a dive or climb phase (PHASE = [1,2])”;
+
+PROFILE_NUMBER:_FillValue = -9999 ;
+
+|Highly desirable
+
+
 |=============================================================
 
 

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -702,7 +702,7 @@ SEGMENT_NUMBER:_FillValue = -9999 ;
 * data type: integer
 * dimension: N_MEASUREMENTS |
 
-PROFILE_NUMBER:long_name = “Identifier of numbered segment within the dataset”;
+PROFILE_NUMBER:long_name = “Identifier of numbered profile within the dataset”;
 
 PROFILE_NUMBER:profile_number_calculation_method = "PROFILE_NUMBER is 1 at the start of a deployment. PROFILE_NUMBER increments by 1 each time a glider enters a dive or climb phase (PHASE = [1,2])”;
 

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -691,7 +691,7 @@ PHASE_QC:flag_meanings = "No QC has been applied,
 
 SEGMENT_NUMBER:long_name = “Identifier of numbered segment within the dataset”;
 
-SEGMENT_NUMBER:segment_number_calculation_method = SEGMENT_NUMBER is 0 at the start of a deployment. SEGMENT_NUMBER increments by 1 each time the glider enters the surface phase (PHASE=3)”;
+SEGMENT_NUMBER:segment_number_calculation_method = SEGMENT_NUMBER is 1 at the start of a deployment. SEGMENT_NUMBER increments by 1 each time the glider enters the surface phase (PHASE=3)”;
 
 SEGMENT_NUMBER:_FillValue = -9999 ;
 
@@ -704,7 +704,7 @@ SEGMENT_NUMBER:_FillValue = -9999 ;
 
 PROFILE_NUMBER:long_name = “Identifier of numbered segment within the dataset”;
 
-PROFILE_NUMBER:profile_number_calculation_method = "PROFILE_NUMBER is 0 at the start of a deployment. PROFILE_NUMBER increments by 1 each time a glider enters a dive or climb phase (PHASE = [1,2])”;
+PROFILE_NUMBER:profile_number_calculation_method = "PROFILE_NUMBER is 1 at the start of a deployment. PROFILE_NUMBER increments by 1 each time a glider enters a dive or climb phase (PHASE = [1,2])”;
 
 PROFILE_NUMBER:_FillValue = -9999 ;
 


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR


- [x] Addition that does not require change in the current structure.


# Related Issues

Proposed to resolve #273 

This adds SEGMENT_NUMBER (surfacing to surfacing) and PROFILE_NUMBER (each time the glider starts a new dive/climb).

How does this look? @emmerbodc @vturpin 

