### PR TITLE
correct vocab names and URIs

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -254,6 +254,7 @@ OG1.0 requirements cover positioning variables and geolocation of any scientific
 * dimension: N_MEASUREMENTS |
 
 * long_name = “Time elapsed since 1970-01-01T00:00:00Z”;
+* standard_name = “time”;
 * calendar = "gregorian" ;
 * units = “seconds since 1970-01-01T00:00:00Z”;
 * _FillValue = -1.0 ;
@@ -261,7 +262,7 @@ OG1.0 requirements cover positioning variables and geolocation of any scientific
 * valid_max = 4e9 ;
 * ancillary_variables = “TIME_QC”;
 * interpolation_methodology = “”;
-* time_vocabulary = “https://vocab.nerc.ac.uk/collection/OG1/current/TIME/”;
+* vocabulary = “http://vocab.nerc.ac.uk/collection/OG1/current/TIME/”;
  |mandatory
 
 |LONGITUDE
@@ -277,7 +278,7 @@ OG1.0 requirements cover positioning variables and geolocation of any scientific
 * valid_max = 180.0;
 * ancillary_variables = "LONGITUDE_QC";
 * interpolation_methodology = “”;
-* longitude_vocabulary = “https://vocab.nerc.ac.uk/collection/OG1/current/LON/”;
+* vocabulary = “http://vocab.nerc.ac.uk/collection/OG1/current/LON/”;
  |mandatory
 
 |LATITUDE
@@ -293,7 +294,7 @@ OG1.0 requirements cover positioning variables and geolocation of any scientific
 * valid_max = 90.0;
 * ancillary_variables = "LATITUDE_QC"
 * interpolation_methodology = “”;
-* latitude_vocabulary = “https://vocab.nerc.ac.uk/collection/OG1/current/LAT/”;
+* vocabulary = “http://vocab.nerc.ac.uk/collection/OG1/current/LAT/”;
  |mandatory
 
 |DEPTH
@@ -309,7 +310,7 @@ OG1.0 requirements cover positioning variables and geolocation of any scientific
 * valid_max = 10000.0;
 * ancillary_variables = "DEPTH_QC"
 * interpolation_methodology = “”;
-* depth_vocabulary = “https://vocab.nerc.ac.uk/collection/OG1/current/DEPTH/”;
+* vocabulary = “http://vocab.nerc.ac.uk/collection/OG1/current/DEPTH/”;
 |mandatory
 
 |============================================================


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [x] Addition that does not require change in the current structure.

# Coordinaates consistency recommendation

Contains the following actions:

- use http, not https in URIs for the NERC vocab server, as they are displayed on the server and recorded in the NVS database (see e.g. URI entry on OG1:TIME) http://vocab.nerc.ac.uk/collection/OG1/current/TIME/
- Add standard_name for time from CF
- Rename vocabulary link attribute from `<variable_name>_vocabulary` to `vocabulary`. This is consistent with how we use it for other variables in the format