### PR TITLE
Add @MOchiara to CODEOWNERS list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
 # This list was created based on the original authors of OG format
 
-* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval @emmerbodc @jenseva @callumrollo @JuangaSocib
+* @glidermann @vturpin @castelao @justinbuck @kerfoot @tcarval @emmerbodc @jenseva @callumrollo @JuangaSocib @MOchiara


### PR DESCRIPTION
Proposal to add Chiara Monforte, glider fleet manager at Hamburg Univeristy, to codeowners.

Hamburg recently acquired a fleet of new Seagliders and are actively developing tools around OG1