### PR TITLE
make standard_name highly desirable for variables

### DIFF
--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -890,8 +890,7 @@ highly desirable
 
 |==========================================================================================================================
 
-
-standard_name to be selected from the https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html[CF standard names table] where available. vocabulary to be selected from the https://vocab.nerc.ac.uk/collection/OG1/current/[OG1 vocabulary].
+The possible values for `vocabulary` are defined in https://vocab.nerc.ac.uk/collection/OG1/current/[OG1 vocabulary].The possible values for `standard_name` are defined in https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html[CF standard names table]. Where an appropriate `standard_name` exists for a variable, it is mandatory to include it in the `standard_name` attribute.
 
 ////
 * [[best-practices]]

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -811,30 +811,30 @@ Geophysical variables are measurements of a physical phenomenon (or an intermedi
 
 The fill value should have the same data type as the variable and be outside the range of possible data values.
 
-[cols="1a,,,",options="header",]
+[cols="1a,,",options="header",]
 |==========================================================================================================================
-|*VARIABLE NAME* |*variable attributes* |*requirement status* | *example*
+|*VARIABLE NAME* |*Variable attributes* and *requirement status* | *Example*
 |<PARAM> 
 
 * data type: float
 * dimension: N_MEASUREMENT |
 
-<PARAM>:long_name = "<X>"; <PARAM>:standard_name = "<X>";
+<PARAM>:long_name; - mandatory
 
-<PARAM>:vocabulary = "";
+<PARAM>:standard_name; - mandatory
 
-<PARAM>:_FillValue = <X>; Note: The fill value should have the same data type as the variable and be outside the range of possible data values.
+<PARAM>:vocabulary; - mandatory
 
-<PARAM>:units = "<X>";
+<PARAM>:_FillValue; - Highly desirable (Note: The fill value should have the same data type as the variable and be outside the range of possible data values.)
 
-<PARAM>:ancillary_variables = "<PARAM>_QC";
+<PARAM>:units; - mandatory
 
-<PARAM>:coordinates = "TIME, LONGITUDE, LATITUDE, DEPTH"
+<PARAM>:ancillary_variables = "<PARAM>_QC"; - highly recommended
 
-<PARAM>:sensor = "SENSOR_<sensor_type>_<sensor_serial_number>"
+<PARAM>:coordinates = "TIME, LONGITUDE, LATITUDE, DEPTH" - mandatory
 
- a|
-mandatory
+<PARAM>:sensor = "SENSOR_<sensor_type>_<sensor_serial_number>" - mandatory
+
 
 <PARAM> contains the values of a parameter listed in the control vocabulary related to OceanGliders parameters.
 
@@ -846,7 +846,7 @@ attributes:
 
 long_name = "Electrical conductivity of the water body by CTD"
 
-standard_name = "<X>";
+standard_name = "sea_water_electrical_conductivity";
 
 vocabulary = "http://vocab.nerc.ac.uk/collection/OG1/current/CNDC/";
 
@@ -863,7 +863,9 @@ sensor = "SENSOR_CTD_206523"
 |<PARAM>_QC 
 
 * data type: byte 
-* dimension: N_MEASUREMENT | 
+* dimension: N_MEASUREMENT |
+
+highly desirable
 
 <PARAM>_QC:long_name = "quality flag";
 
@@ -884,10 +886,12 @@ sensor = "SENSOR_CTD_206523"
 <PARAM>_QC:RTQC_methodology_vocabulary = “”;
 
 <PARAM>_QC:RTQC_methodology_doi = “”;
+|
 
- |higly desirable |
 |==========================================================================================================================
 
+
+standard_name to be selected from the https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html[CF standard names table] where available. vocabulary to be selected from the https://vocab.nerc.ac.uk/collection/OG1/current/[OG1 vocabulary].
 
 ////
 * [[best-practices]]

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -890,7 +890,7 @@ highly desirable
 
 |==========================================================================================================================
 
-The possible values for `vocabulary` are defined in https://vocab.nerc.ac.uk/collection/OG1/current/[OG1 vocabulary].The possible values for `standard_name` are defined in https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html[CF standard names table]. Where an appropriate `standard_name` exists for a variable, it is mandatory to include it in the `standard_name` attribute.
+The possible values for `vocabulary` are defined in https://vocab.nerc.ac.uk/collection/OG1/current/[OG1 vocabulary]. The possible values for `standard_name` are defined in https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html[CF standard names table]. Where an appropriate `standard_name` exists for a variable, it is mandatory to include it in the `standard_name` attribute.
 
 ////
 * [[best-practices]]

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -838,8 +838,6 @@ The fill value should have the same data type as the variable and be outside the
 
 <PARAM> contains the values of a parameter listed in the control vocabulary related to OceanGliders parameters.
 
-<X>: these fields are specified in the control vocabularies.
-
 | CNDC(N_MEASUREMENT);
 
 attributes:

--- a/OG_Format.adoc
+++ b/OG_Format.adoc
@@ -821,7 +821,7 @@ The fill value should have the same data type as the variable and be outside the
 
 <PARAM>:long_name; - mandatory
 
-<PARAM>:standard_name; - mandatory
+<PARAM>:standard_name; - highly desirable
 
 <PARAM>:vocabulary; - mandatory
 
@@ -829,7 +829,7 @@ The fill value should have the same data type as the variable and be outside the
 
 <PARAM>:units; - mandatory
 
-<PARAM>:ancillary_variables = "<PARAM>_QC"; - highly recommended
+<PARAM>:ancillary_variables = "<PARAM>_QC"; - highly desirable
 
 <PARAM>:coordinates = "TIME, LONGITUDE, LATITUDE, DEPTH" - mandatory
 


### PR DESCRIPTION
Proponents: <!-- Add the proponents here -->
Moderator: @OceanGlidersCommunity/format-mantainers

# Type of PR

- [x] Fix of some error, inconsistency, unforeseen limitation.

# Related Issues

This will resolve #296


------------------

Submitting this PR to make `standard_name`a highly recommended attribute, as there are many variables in ocean gliders files (e.g. oil volume in the bladder) that are very unlikely to be accepted into CF standard names table, and therefore cannot be mandatory.

I tidied up the table to clarify which attributes are mandatory 